### PR TITLE
Warnings removed & Windows support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "3rdParty/zlib"]
+	path = 3rdParty/zlib
+	url = https://github.com/madler/zlib

--- a/telegram-qt/CRawStream.hpp
+++ b/telegram-qt/CRawStream.hpp
@@ -20,12 +20,13 @@
 
 #include "TLNumbers.hpp"
 #include "TLValues.h"
+#include "telegramqt_export.h"
 
 QT_BEGIN_NAMESPACE
 class QIODevice;
 QT_END_NAMESPACE
 
-class CRawStream
+class TELEGRAMQT_EXPORT CRawStream
 {
 public:
     explicit CRawStream(QByteArray *data, bool write);

--- a/telegram-qt/CTelegramConnection.cpp
+++ b/telegram-qt/CTelegramConnection.cpp
@@ -1385,6 +1385,7 @@ void CTelegramConnection::processIgnoredMessageNotification(CTelegramStream &str
 
 TLValue CTelegramConnection::processHelpGetConfig(CTelegramStream &stream, quint64 id)
 {
+    Q_UNUSED(id);
     TLConfig result;
     stream >> result;
 
@@ -1403,6 +1404,7 @@ TLValue CTelegramConnection::processHelpGetConfig(CTelegramStream &stream, quint
 
 TLValue CTelegramConnection::processContactsGetContacts(CTelegramStream &stream, quint64 id)
 {
+    Q_UNUSED(id);
     TLContactsContacts result;
     stream >> result;
 
@@ -1422,6 +1424,7 @@ TLValue CTelegramConnection::processContactsGetContacts(CTelegramStream &stream,
 
 TLValue CTelegramConnection::processContactsImportContacts(CTelegramStream &stream, quint64 id)
 {
+    Q_UNUSED(id);
     TLContactsImportedContacts result;
     stream >> result;
 
@@ -1441,6 +1444,7 @@ TLValue CTelegramConnection::processContactsImportContacts(CTelegramStream &stre
 
 TLValue CTelegramConnection::processContactsDeleteContacts(CTelegramStream &stream, quint64 id)
 {
+    Q_UNUSED(id);
     TLValue result;
     stream >> result;
 
@@ -1449,6 +1453,7 @@ TLValue CTelegramConnection::processContactsDeleteContacts(CTelegramStream &stre
 
 TLValue CTelegramConnection::processUpdatesGetState(CTelegramStream &stream, quint64 id)
 {
+    Q_UNUSED(id);
     TLUpdatesState result;
     stream >> result;
 
@@ -1465,6 +1470,7 @@ TLValue CTelegramConnection::processUpdatesGetState(CTelegramStream &stream, qui
 
 TLValue CTelegramConnection::processUpdatesGetDifference(CTelegramStream &stream, quint64 id)
 {
+    Q_UNUSED(id);
     TLUpdatesDifference result;
     stream >> result;
 
@@ -1508,6 +1514,7 @@ TLValue CTelegramConnection::processAuthCheckPhone(CTelegramStream &stream, quin
 
 TLValue CTelegramConnection::processAuthSendCode(CTelegramStream &stream, quint64 id)
 {
+    Q_UNUSED(id);
     TLAuthSentCode result;
     stream >> result;
 
@@ -1522,6 +1529,7 @@ TLValue CTelegramConnection::processAuthSendCode(CTelegramStream &stream, quint6
 
 TLValue CTelegramConnection::processAuthSign(CTelegramStream &stream, quint64 id)
 {
+    Q_UNUSED(id);
     TLAuthAuthorization result;
     stream >> result;
 
@@ -1549,6 +1557,7 @@ TLValue CTelegramConnection::processUploadGetFile(CTelegramStream &stream, quint
 
 TLValue CTelegramConnection::processUsersGetUsers(CTelegramStream &stream, quint64 id)
 {
+    Q_UNUSED(id);
     TLVector<TLUser> result;
 
     stream >> result;
@@ -1562,6 +1571,7 @@ TLValue CTelegramConnection::processUsersGetUsers(CTelegramStream &stream, quint
 
 TLValue CTelegramConnection::processUsersGetFullUser(CTelegramStream &stream, quint64 id)
 {
+    Q_UNUSED(id);
     TLUserFull result;
 
     stream >> result;
@@ -1621,6 +1631,7 @@ TLValue CTelegramConnection::processMessagesSendMessage(CTelegramStream &stream,
 
 TLValue CTelegramConnection::processMessagesSetTyping(CTelegramStream &stream, quint64 id)
 {
+    Q_UNUSED(id);
     TLValue result;
     stream >> result;
 
@@ -1629,6 +1640,7 @@ TLValue CTelegramConnection::processMessagesSetTyping(CTelegramStream &stream, q
 
 TLValue CTelegramConnection::processMessagesReadHistory(CTelegramStream &stream, quint64 id)
 {
+    Q_UNUSED(id);
     TLMessagesAffectedHistory result;
     stream >> result;
 
@@ -1637,6 +1649,7 @@ TLValue CTelegramConnection::processMessagesReadHistory(CTelegramStream &stream,
 
 TLValue CTelegramConnection::processMessagesReceivedMessages(CTelegramStream &stream, quint64 id)
 {
+    Q_UNUSED(id);
     TLVector<quint32> result;
     stream >> result;
 
@@ -1645,6 +1658,7 @@ TLValue CTelegramConnection::processMessagesReceivedMessages(CTelegramStream &st
 
 TLValue CTelegramConnection::processAccountUpdateStatus(CTelegramStream &stream, quint64 id)
 {
+    Q_UNUSED(id);
     TLValue result;
     stream >> result;
 

--- a/telegram-qt/CTelegramConnection.hpp
+++ b/telegram-qt/CTelegramConnection.hpp
@@ -23,12 +23,13 @@
 #include "TLTypes.hpp"
 #include "crypto-rsa.hpp"
 #include "crypto-aes.hpp"
+#include "telegramqt_export.h"
 
 class CAppInformation;
 class CTelegramStream;
 class CTelegramTransport;
 
-class CTelegramConnection : public QObject
+class TELEGRAMQT_EXPORT CTelegramConnection : public QObject
 {
     Q_OBJECT
 public:

--- a/telegram-qt/CTelegramStream.cpp
+++ b/telegram-qt/CTelegramStream.cpp
@@ -87,7 +87,7 @@ CTelegramStream &CTelegramStream::operator>>(TLVector<T> &v)
     if (result.tlType == Vector) {
         quint32 length = 0;
         *this >> length;
-        for (int i = 0; i < length; ++i) {
+        for (quint32 i = 0; i < length; ++i) {
             T value;
             *this >> value;
             result.append(value);

--- a/telegram-qt/CTelegramStream.hpp
+++ b/telegram-qt/CTelegramStream.hpp
@@ -19,8 +19,9 @@
 
 #include "CRawStream.hpp"
 #include "TLTypes.hpp"
+#include "telegramqt_export.h"
 
-class CTelegramStream : public CRawStream
+class TELEGRAMQT_EXPORT CTelegramStream : public CRawStream
 {
 public:
     explicit CTelegramStream(QByteArray *data, bool write);
@@ -38,6 +39,66 @@ public:
 
     template <typename T>
     CTelegramStream &operator>>(TLVector<T> &v);
+
+    CTelegramStream &operator>>(TLVector<unsigned __int64> &v)
+    {
+        TLVector<unsigned __int64> result;
+
+        *this >> result.tlType;
+
+        if (result.tlType == Vector) {
+            quint32 length = 0;
+            *this >> length;
+            for (quint32 i = 0; i < length; ++i) {
+                unsigned __int64 value;
+                *this >> value;
+                result.append(value);
+            }
+        }
+
+        v = result;
+        return *this;
+    }
+
+    CTelegramStream &operator>>(TLVector<unsigned int> &v)
+    {
+        TLVector<unsigned int> result;
+
+        *this >> result.tlType;
+
+        if (result.tlType == Vector) {
+            quint32 length = 0;
+            *this >> length;
+            for (quint32 i = 0; i < length; ++i) {
+                unsigned int value;
+                *this >> value;
+                result.append(value);
+            }
+        }
+
+        v = result;
+        return *this;
+    }
+
+    CTelegramStream &operator>>(TLVector<TLDcOption> &v)
+    {
+        TLVector<TLDcOption> result;
+
+        *this >> result.tlType;
+
+        if (result.tlType == Vector) {
+            quint32 length = 0;
+            *this >> length;
+            for (quint32 i = 0; i < length; ++i) {
+                TLDcOption value;
+                *this >> value;
+                result.append(value);
+            }
+        }
+
+        v = result;
+        return *this;
+    }
 
     // Generated read operators
     CTelegramStream &operator>>(TLAudio &audio);
@@ -175,6 +236,20 @@ public:
     template <typename T>
     CTelegramStream &operator<<(const TLVector<T> &v);
 
+    CTelegramStream &operator<<(const TLVector<quint64> &v)
+    {
+        *this << v.tlType;
+
+        if (v.tlType == Vector) {
+            *this << v.count();
+
+            for (int i = 0; i < v.count(); ++i) {
+                *this << v.at(i);
+            }
+        }
+
+        return *this;
+    }
 };
 
 inline CTelegramStream &CTelegramStream::operator>>(QString &str)

--- a/telegram-qt/telegram-qt.pro
+++ b/telegram-qt/telegram-qt.pro
@@ -35,4 +35,23 @@ HEADERS = CTelegramCore.hpp \
 
 HEADERS += TLValues.h
 
-LIBS += -lssl
+win32 {
+    INCLUDEPATH += ../3rdParty/zlib
+    DEFINES += _CRT_SECURE_NO_WARNINGS
+    LIBS += -lUser32 -lAdvapi32 -lGdi32
+    SOURCES += ../3rdParty/zlib/inflate.c \
+        ../3rdParty/zlib/adler32.c \
+        ../3rdParty/zlib/crc32.c \
+        ../3rdParty/zlib/zutil.c \
+        ../3rdParty/zlib/inftrees.c \
+        ../3rdParty/zlib/inffast.c
+    CONFIG(debug) {
+        DESTDIR = ../bin/debug
+        LIBS += -lssleay32MDd -llibeay32MDd
+    } else {
+        DESTDIR = ../bin/release
+        LIBS += -lssleay32MD -llibeay32MD
+    }
+} else {
+    LIBS += -lssl
+}

--- a/testApp/testApp.pro
+++ b/testApp/testApp.pro
@@ -11,8 +11,23 @@ TEMPLATE = app
 INCLUDEPATH += $$PWD/../telegram-qt
 
 LIBS += -lTelegramQt
-LIBS += -lssl
-LIBS += -L$$OUT_PWD/../telegram-qt
+
+win32 {
+    CONFIG(debug) {
+        LIBS += -L$$PWD/../bin/debug
+        LIBS += -lssleay32MDd -llibeay32MDd
+        DESTDIR = $$PWD/../bin/debug
+    } else {
+        LIBS += -L$$PWD/../bin/release
+        LIBS += -lssleay32MD -llibeay32MD
+        DESTDIR = $$PWD/../bin/release
+    }
+    LIBS += -lUser32 -lAdvapi32 -lGdi32
+} else {
+    LIBS += -L$$OUT_PWD/../telegram-qt
+    LIBS += -lssl
+}
+
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
@@ -20,7 +35,7 @@ TARGET = testApp
 TEMPLATE = app
 
 SOURCES += main.cpp\
-        MainWindow.cpp \
+    MainWindow.cpp \
     CContactModel.cpp \
     CMessagingModel.cpp
 

--- a/tests/connection/tst_CTelegramConnection.cpp
+++ b/tests/connection/tst_CTelegramConnection.cpp
@@ -11,6 +11,7 @@
 
 */
 
+#include <array>
 #include <QObject>
 
 #include "CTestConnection.hpp"
@@ -104,14 +105,10 @@ void tst_CTelegramConnection::testPQAuthRequest()
 
     QCOMPARE(encoded.mid(18, 4), messageBodyLength); // Expected payload length is 20 bytes
 
-    QByteArray reqPqRaw;
-    reqPqRaw.resize(4);
-    reqPqRaw[0] = 0x78;
-    reqPqRaw[1] = 0x97;
-    reqPqRaw[2] = 0x46;
-    reqPqRaw[3] = 0x60;
+    std::array<quint8, 4> reqPqRaw {{0x78, 0x97, 0x46, 0x60}};
 
-    QCOMPARE(encoded.mid(22, 4), reqPqRaw); // Expected payload length is 20 bytes
+    QCOMPARE(encoded.mid(22, 4), QByteArray(reinterpret_cast<char*>(reqPqRaw.data()),
+        static_cast<int>(reqPqRaw.size()))); // Expected payload length is 20 bytes
 }
 
 void tst_CTelegramConnection::testAuth()

--- a/tests/tests.pri
+++ b/tests/tests.pri
@@ -5,5 +5,19 @@ TEMPLATE = app
 INCLUDEPATH += $$PWD/../telegram-qt
 
 LIBS += -lTelegramQt
-LIBS += -lssl
-LIBS += -L$$OUT_PWD/../../telegram-qt
+
+win32 {
+    CONFIG(debug) {
+        LIBS += -L$$PWD/../bin/debug
+        LIBS += -lssleay32MDd -llibeay32MDd
+        DESTDIR = $$PWD/../bin/debug
+    } else {
+        LIBS += -L$$PWD/../bin/release
+        LIBS += -lssleay32MD -llibeay32MD
+        DESTDIR = $$PWD/../bin/release
+    }
+    LIBS += -lUser32 -lAdvapi32 -lGdi32
+} else {
+    LIBS += -L$$OUT_PWD/../../telegram-qt
+    LIBS += -lssl
+}


### PR DESCRIPTION
Hello, I added Windows support to your library. (Checked and working).

I am creating a Telegram Client for Sailfish OS and I started wrapping telegram-cli but this way was unmaintainable. I found your Qt library and looks good, so I would like to start using it.

At this moment I only can use Windows on my machine so I would like to test the code firstly on Windows. This is why I fixed the project for support Windows.

Tested on Windows 10 with Visual Studio 2013 x64.